### PR TITLE
Preserving local web-ui, added --force-update-gui option to force checkout a new copy of web ui

### DIFF
--- a/spotdl/console/web.py
+++ b/spotdl/console/web.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import sys
 import webbrowser
+import os
 
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -62,13 +63,14 @@ def web(web_settings: WebOptions, downloader_settings: DownloaderOptions):
 
     downloader_settings["simple_tui"] = True
 
-    # Download web app from GitHub
-    logger.info("Updating web app \n")
+    # Download web app from GitHub if not already downloaded or force flag set
     web_app_dir = str(get_spotdl_path().absolute())
-    download_github_dir(
-        "https://github.com/spotdl/web-ui/tree/master/dist",
-        output_dir=web_app_dir,
-    )
+    if not os.path.exists(web_app_dir) or web_settings["force_update_gui"]:
+        logger.info("Updating web app \n")
+        download_github_dir(
+            "https://github.com/spotdl/web-ui/tree/master/dist",
+            output_dir=web_app_dir,
+        )
 
     app_state.api = FastAPI(
         title="spotDL",

--- a/spotdl/types/options.py
+++ b/spotdl/types/options.py
@@ -99,6 +99,7 @@ class WebOptions(TypedDict):
     keep_alive: bool
     allowed_origins: Optional[List[str]]
     keep_sessions: bool
+    force_update_gui: bool
 
 
 class SpotDLOptions(SpotifyOptions, DownloaderOptions, WebOptions):

--- a/spotdl/utils/arguments.py
+++ b/spotdl/utils/arguments.py
@@ -659,6 +659,15 @@ def parse_web_options(parser: _ArgumentGroup):
         help="Keep the session directory after the web server is closed.",
     )
 
+    # Add keep sessions argument
+    parser.add_argument(
+        "--force-update-gui",
+        action="store_const",
+        const=True,
+        default=False,
+        help="Refresh the web server directory with a fresh git checkout",
+    )
+
 
 def parse_misc_options(parser: _ArgumentGroup):
     """

--- a/spotdl/utils/config.py
+++ b/spotdl/utils/config.py
@@ -339,6 +339,7 @@ WEB_OPTIONS: WebOptions = {
     "keep_alive": False,
     "allowed_origins": None,
     "keep_sessions": False,
+    "force_update_gui": False,
 }
 
 # Type: ignore because of the issues above


### PR DESCRIPTION
# Title
Preserving local web-ui, added --force-update-gui option to force checkout a new copy of web ui

## Description
### Problem 
`spotdl web --port <port_num>`  command downloads the web-ui code from Github and runs it on the specified port. However, the compiled web-ui always points to port 8080, causing API failures on local. This requires a manual port change in the local web-ui repo which gets refreshed on every web run.

### Solution
Checking if web-ui folder already exists on local before pulling in a fresh checkout.
Added `--force-update-gui` option to force pull the ui repo

## Related Issue

- Resolves [local web-ui #2068](https://github.com/spotDL/spotify-downloader/issues/2068)
- Addresses [Web-ui Not Using Designated Port #2067](https://github.com/spotDL/spotify-downloader/issues/2067)

## Motivation and Context
Helps me run the web ui on a different port without having to manually change the port numbers on every run

## How Has This Been Tested?
Since this is such a small change, I just ran some manual tests and checked compilation still worked.

## Screenshots (if appropriate)

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document
- [x] I have read the  [CORE VALUES](/docs/CORE_VALUES.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
